### PR TITLE
Fix broken link and improve formatting/language

### DIFF
--- a/panel_table.html
+++ b/panel_table.html
@@ -45,7 +45,7 @@
 
                 <tfoot>
                     <tr>
-                        <th colspan="15" style="text-align: center; font-size: 14px"><a href="https://django-query-profiler.readthedocs.io/en/latest/chromium_plugin_columns.html"
+                        <th colspan="15" style="text-align: center; font-size: 14px"><a href="https://django-query-profiler.readthedocs.io/en/latest/chrome_plugin_columns.html"
                                 target="_blank">What does the above columns mean</a></th>
                     </tr>
                 </tfoot>

--- a/panel_table.html
+++ b/panel_table.html
@@ -10,17 +10,17 @@
         </div>
 
         <div class="button" style="float: right;">
-            <input type="button" class="button" value="Export to excel" id="export-to-excel">
+            <input type="button" class="button" value="Export to Excel" id="export-to-excel">
         </div>
 
 
         <div class="wrap">
             <TABLE id="panel_table_id" class="tblClass">
-                <CAPTION>Django query profiler data</CAPTION>
+                <CAPTION>Django Query Profiler Data</CAPTION>
 
                 <thead style="position: sticky; top: 0;">
                 <tr>
-                    <th width="72px" >Api name</th>
+                    <th width="72px">API name</th>
                     <th width="6px">Total request time <br/>(in ms)</th>
                     <th width="6px">Server request time <br/> (in ms)</th>
                     <th width="6px">Profiler time added <br/>(in ms)</th>
@@ -30,12 +30,12 @@
                     <th width="5px">Insert</th>
                     <th width="5px">Update</th>
                     <th width="5px">Delete</th>
-                    <th width="8px">Transactional sqls</th>
-                    <th width="8px">Other sqls</th>
+                    <th width="8px">Transactional SQLs</th>
+                    <th width="8px">Other SQLs</th>
 
                     <th width="10px">DB Rows fetched</th>
                     <th width="5px">Potential N+1's</th>
-                    <th width="5px">Exact sql duplicates</th>
+                    <th width="5px">Exact SQL duplicates</th>
                     <th width="20px">Details link</th>
                 </tr>
                 </thead>
@@ -45,8 +45,11 @@
 
                 <tfoot>
                     <tr>
-                        <th colspan="15" style="text-align: center; font-size: 14px"><a href="https://django-query-profiler.readthedocs.io/en/latest/chrome_plugin_columns.html"
-                                target="_blank">What does the above columns mean</a></th>
+                        <th colspan="15" style="text-align: center; font-size: 14px">
+                            <a href="https://django-query-profiler.readthedocs.io/en/latest/chrome_plugin_columns.html" target="_blank">
+                                What do the above columns mean
+                            </a>
+                        </th>
                     </tr>
                 </tfoot>
 


### PR DESCRIPTION
The URL for the link of what the columns mean was incorrect.  This updates the link to point to the correct place.  Additionally, some minor formatting/language fixes.